### PR TITLE
Remove line break in response dot templates

### DIFF
--- a/templates/response_headers.dot
+++ b/templates/response_headers.dot
@@ -2,5 +2,4 @@
 
 Status|Header|Type|Format|Description
 ---|---|---|---|---|
-{{~ data.response_headers :h}}{{=h.status}}|{{=h.header}}|{{=h.type}}|{{=h.format}}|{{=h.description}}
-{{~}}
+{{~ data.response_headers :h}}{{=h.status}}|{{=h.header}}|{{=h.type}}|{{=h.format}}|{{=h.description}}{{~}}

--- a/templates/responses.dot
+++ b/templates/responses.dot
@@ -2,5 +2,4 @@
 
 Status|Meaning|Description
 ---|---|---|
-{{~ data.responses :r}}{{=r.status}}|{{=r.meaning}}|{{=r.description}}
-{{~}}
+{{~ data.responses :r}}{{=r.status}}|{{=r.meaning}}|{{=r.description}}{{~}}


### PR DESCRIPTION
#### What?

Removed a line break for the closing iterator so prevent the same line break from breaking the markdown table format. 

#### Screenshots
 
Will post after the S3 outage is done

**Before changes**
```md
Status|Meaning|Description
---|---|---|
200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A product.

409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|`Product` was in conflict with another product. This is the result of duplicate unique values, such as name or SKU; a missing or invalid category id, brand id, or tax_class id; or a conflicting `bulk_pricing_rule`.

422|[Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)|`Product` was not valid. This is the result of missing required fields, or of invalid data. See the response for more details.

```

**After changes**
```md
Status|Meaning|Description
---|---|---|
200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A product.
409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|`Product` was in conflict with another product. This is the result of duplicate unique values, such as name or SKU; a missing or invalid category id, brand id, or tax_class id; or a conflicting `bulk_pricing_rule`.
422|[Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)|`Product` was not valid. This is the result of missing required fields, or of invalid data. See the response for more details.
```
