### PR TITLE
Templates/code_shell: use upper cased http method

### DIFF
--- a/templates/openapi3/code_shell.dot
+++ b/templates/openapi3/code_shell.dot
@@ -1,4 +1,4 @@
 # You can also use wget
-curl -X {{=data.method}} {{=data.url}}{{=data.requiredQueryString}}{{?data.allHeaders.length}} \{{?}}
+curl -X {{=data.methodUpper}} {{=data.url}}{{=data.requiredQueryString}}{{?data.allHeaders.length}} \{{?}}
 {{~data.allHeaders :p:index}}  -H '{{=p.name}}: {{=p.exampleValues.object}}'{{?index < data.allHeaders.length-1}} \{{?}}
 {{~}}


### PR DESCRIPTION
Http methods are enums, and they are all in uppercase. 