### PR TITLE
Allow new languages from user templates

### DIFF
--- a/asyncapi.js
+++ b/asyncapi.js
@@ -104,7 +104,7 @@ function processObject(obj, options, asyncapi) {
 function convert(asyncapi, options, callback) {
 
 	var defaults = {};
-	defaults.language_tabs = [{ 'javascript--nodejs': 'Node.JS' },{ 'javascript': 'JavaScript' }, { 'python': 'Python' }, { 'ruby': 'Ruby' }, { 'java': 'Java' }, { 'go': 'Go'}];
+	defaults.language_tabs = [{ 'javascript--nodejs': 'Node.JS' },{ 'javascript': 'JavaScript' }, { 'ruby': 'Ruby' }, { 'python': 'Python' }, { 'java': 'Java' }, { 'go': 'Go'}];
 	defaults.codeSamples = true;
 	defaults.theme = 'darkula';
 	defaults.search = true;
@@ -251,14 +251,17 @@ function convert(asyncapi, options, callback) {
 							}
 							var lcLang = common.languageCheck(l, header.language_tabs, false);
 							if (lcLang) {
-								content += '```' + lcLang + '\n';
-								var langSuffixForTemplate = lcLang.substring(lcLang.lastIndexOf('-') + 1);
-								data = options.templateCallback('code_' + langSuffixForTemplate, 'pre', data);
-								if (data.append) { content += data.append; delete data.append; }
-								content += templates['code_' + langSuffixForTemplate](data);
-								data = options.templateCallback('code_' + langSuffixForTemplate, 'post', data);
-								if (data.append) { content += data.append; delete data.append; }
-								content += '```\n\n';
+                                var templateName = 'code_' + lcLang.substring(lcLang.lastIndexOf('-') + 1);
+                                var templateFunc = templates[templateName];
+                                if (templateFunc) {
+                                    content += '```' + lcLang + '\n';
+                                    data = options.templateCallback(templateName, 'pre', data);
+                                    if (data.append) { content += data.append; delete data.append; }
+                                    content += templateFunc(data);
+                                    data = options.templateCallback(templateName, 'post', data);
+                                    if (data.append) { content += data.append; delete data.append; }
+                                    content += '```\n\n';
+                                }
 							}
 						}
 					}

--- a/openapi3.js
+++ b/openapi3.js
@@ -275,14 +275,17 @@ function processOperation(op, method, resource, options) {
 				}
 				var lcLang = common.languageCheck(l, header.language_tabs, false);
 				if (lcLang) {
-					content += '```' + lcLang + '\n';
-					var langSuffixForTemplate = lcLang.substring(lcLang.lastIndexOf('-') + 1);
-					data = options.templateCallback('code_' + langSuffixForTemplate, 'pre', data);
-					if (data.append) { content += data.append; delete data.append; }
-					content += templates['code_' + langSuffixForTemplate](data);
-					data = options.templateCallback('code_' + langSuffixForTemplate, 'post', data);
-					if (data.append) { content += data.append; delete data.append; }
-					content += '```\n\n';
+					var templateName = 'code_'+lcLang.substring(lcLang.lastIndexOf('-') + 1);
+                    var templateFunc = templates[templateName];
+                    if (templateFunc) {
+                        content += '```' + lcLang + '\n';
+                        data = options.templateCallback(templateName, 'pre', data);
+                        if (data.append) { content += data.append; delete data.append; }
+                        content += templateFunc(data);
+                        data = options.templateCallback(templateName, 'post', data);
+                        if (data.append) { content += data.append; delete data.append; }
+                        content += '```\n\n';
+                    }
 				}
 			}
 		}
@@ -622,7 +625,7 @@ function processOperation(op, method, resource, options) {
 function convert(openapi, options, callback) {
 
 	var defaults = {};
-	defaults.language_tabs = [{ 'shell': 'Shell' }, { 'http': 'HTTP' }, { 'javascript': 'JavaScript' }, { 'javascript--nodejs': 'Node.JS' }, { 'python': 'Python' }, { 'ruby': 'Ruby' }, { 'java': 'Java' }];
+	defaults.language_tabs = [{ 'shell': 'Shell' }, { 'http': 'HTTP' }, { 'javascript': 'JavaScript' }, { 'javascript--nodejs': 'Node.JS' }, { 'ruby': 'Ruby' }, { 'python': 'Python' }, { 'java': 'Java' }];
 	defaults.codeSamples = true;
 	defaults.theme = 'darkula';
 	defaults.search = true;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "widdershins",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "OpenApi / Swagger / AsyncAPI definition to slate / shins compatible markdown",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Instead of hardcoding a list of languages that have default templates, dynamically load the templates from the language option and load templates accordingly (including from user template directory). This allows a user to add a custom template for a language that doesn't have a default, like php, without having to mess around with the internals. 