### PR TITLE
Generate parameter examples from referenced types.

### DIFF
--- a/openapi3.js
+++ b/openapi3.js
@@ -186,7 +186,12 @@ function processOperation(op, method, resource, options) {
 		if (param.schema && param.schema.format) {
 			param.safeType = param.safeType + '(' + param.schema.format + ')';
 		}
-		param.exampleSchema = param.schema || {};
+		if (param.schema && param.schema["$ref"]) {
+			param.exampleSchema = jptr.jptr(data.openapi, param.schema["$ref"]);
+		}
+		else {
+			param.exampleSchema = param.schema || {};
+		}
 		param.exampleValues = {};
 		param.exampleValues.json = '{}';
 		param.exampleValues.object = {};


### PR DESCRIPTION
When generating example values for parameters, pass the referenced definition to the sampler instead of just the reference. 

This allows for 'complex' string references to not show up as a generic object reference in the example. 