### PR TITLE
change name attribute to id for scema anchors

### DIFF
--- a/asyncapi.js
+++ b/asyncapi.js
@@ -314,7 +314,7 @@ function convert(asyncapi, options, callback) {
 
         for (let s in asyncapi.components.schemas) {
             content += '## '+s+'\n\n';
-            content += '<a name="schema'+s.toLowerCase()+'"></a>\n\n';
+            content += '<a id="schema'+s.toLowerCase()+'"></a>\n\n';
             let schema = asyncapi.components.schemas[s];
             schema = common.dereference(schema, circles, asyncapi, common.clone, options.aggressive);
 

--- a/openapi3.js
+++ b/openapi3.js
@@ -758,7 +758,7 @@ function convert(openapi, options, callback) {
 
         for (let s in openapi.components.schemas) {
             content += '## '+s+'\n\n';
-            content += '<a name="schema'+s.toLowerCase()+'"></a>\n\n';
+            content += '<a id="schema'+s.toLowerCase()+'"></a>\n\n';
             let schema = openapi.components.schemas[s];
             schema = common.dereference(schema, circles, openapi, common.clone, options.aggressive);
 


### PR DESCRIPTION
The 'name' attribute is invalid in HTML5 for anchors

Reference:
https://stackoverflow.com/questions/484719/html-anchors-with-name-or-id
