### PR TITLE
Special support for enum in response schemata

### DIFF
--- a/common.js
+++ b/common.js
@@ -163,6 +163,9 @@ function schemaToArray(schema,offset,options,data) {
     let wsState = wsGetState();
     wsState.combine = true;
     walkSchema(schema,{},wsState,function(schema,parent,state){
+        if (schema.enum && Array.isArray(schema.enum)) {
+            schema.type = 'enum(' + schema.enum.join(', ') + ')';
+        }
 
         let isBlock = false;
         if (state.property && (state.property.startsWith('allOf') || state.property.startsWith('anyOf') || state.property.startsWith('oneOf') || (state.property === 'not'))) {

--- a/templates/openapi3/responses.def
+++ b/templates/openapi3/responses.def
@@ -36,7 +36,7 @@ Status Code **{{=response.status}}**
 |Name|Type|Required|Description|
 |---|---|---|---|{{??}}*{{=block.title}}*
 {{?}}
-{{~block.rows :p}}|{{=p.displayName}}|{{=p.safeType}}|{{=p.required}}|{{=p.description||'No description'}}|
+{{~block.rows :p}}|<span style="white-space:nowrap">{{=p.displayName}}</span>|{{=p.safeType}}|{{=p.required}}|{{=p.description||'No description'}}|
 {{~}}
 {{~}}
 


### PR DESCRIPTION
This is probably not the correct way to implement this on this project, but it's got me going for now and probably serves as a reminder to include enum support more than anything.

It produces the following response schema table:

![screen shot 2018-02-08 at 15 49 53](https://user-images.githubusercontent.com/65215/35957547-d1cb78ac-0ce7-11e8-8dab-c643a8566751.png)

From something like:

```json
{
  "$schema": "http://json-schema.org/draft-07/hyper-schema#",
  "title": "Pet",
  "type": "object",
  "properties": {
    "name": {
      "type": "string",
      "description": "The name of the pet"
    },
    "species": {
      "type": "string",
      "enum": [
        "chincilla",
        "dog",
        "cat"
      ],
      "description": "The species of the the pet in question"
    },
    "ownerMemberNumber": {
      "type": "string",
      "description": "Owner member number"
    }
  },
  "links": [
    {
      "rel": "self",
      "href": "owner/{memberNumber}"
    }
  ]
}
```

This also includes a change to stop name wrapping in the same table with 

```html
<span style="white-space:nowrap">{{=p.displayName}}</span>
```