### PR TITLE
Bearer auth example changed.

### DIFF
--- a/openapi3.js
+++ b/openapi3.js
@@ -244,7 +244,7 @@ function getParameters(data) {
                 authHeader.in = 'header';
                 authHeader.isAuth = true;
                 authHeader.exampleValues = {};
-                authHeader.exampleValues.object = 'bearer {access-token}';
+                authHeader.exampleValues.object = 'Bearer {access-token}';
                 authHeader.exampleValues.json = "'" + authHeader.exampleValues.object + "'";
                 data.allHeaders.push(authHeader);
             }


### PR DESCRIPTION
Bearer header syntax must be as follows:
```
     b64token    = 1*( ALPHA / DIGIT /
                       "-" / "." / "_" / "~" / "+" / "/" ) *"="
     credentials = "Bearer" 1*SP b64token
```
https://github.com/Mermade/widdershins/issues/113