### PR TITLE
Modified schema title assignment

### DIFF
--- a/common.js
+++ b/common.js
@@ -198,9 +198,9 @@ function schemaToArray(schema,offset,options,data) {
         if (schema.title) block.title = schema.title;
         if (!block.title && schema.description)
             block.title = schema.description;
-        else if (schema.description)
-            block.description = schema.description;
-        if (schema.externalDocs) block.externalDocs = schema.externalDocs;
+        block.description = schema.description;
+        if (schema.externalDocs)
+            block.externalDocs = schema.externalDocs;
     }
     container.push(block);
     let wsState = wsGetState();

--- a/common.js
+++ b/common.js
@@ -195,8 +195,11 @@ function schemaToArray(schema,offset,options,data) {
     let container = [];
     let block = { title: '', rows: [] };
     if (schema) {
-        if (schema.description) block.title = schema.description;
-        if (!block.title && schema.title) block.title = schema.title;
+        if (schema.title) block.title = schema.title;
+        if (!block.title && schema.description)
+            block.title = schema.description;
+        else if (schema.description)
+            block.description = schema.description;
         if (schema.externalDocs) block.externalDocs = schema.externalDocs;
     }
     container.push(block);


### PR DESCRIPTION
Schema titles should attempt to be assigned to their actual titles from the spec file first, before using the description.

If a doc-writer wants to have the description as the title in the documentation center, they should do so in the template.