### PR TITLE
Remove emphasis so multi-line descriptions render correctly

### DIFF
--- a/templates/openapi3/main.dot
+++ b/templates/openapi3/main.dot
@@ -55,9 +55,9 @@ Base URLs:
 {{ var origSchema = data.components.schemas[s]; }}
 {{ var schema = data.api.components.schemas[s]; }}
 
-<h2 id="tocS{{=s.toLowerCase()}}">{{=s}}</h2>
-
 <a id="schema{{=s.toLowerCase()}}"></a>
+
+<h2 id="tocS{{=s.toLowerCase()}}">{{=s}}</h2>
 
 {{? data.options.yaml }}
 ```yaml
@@ -82,7 +82,7 @@ Base URLs:
 }}
 
 {{~ blocks :block}}
-{{? block.title }}*{{= block.title}}*{{= '\n\n'}}{{?}}
+{{? block.title }}{{= block.title}}{{= '\n\n'}}{{?}}
 {{? block.externalDocs}}
 <a href="{{=block.externalDocs.url}}">{{=block.externalDocs.description||'External documentation'}}</a>
 {{?}}


### PR DESCRIPTION
Adjust position of id link so that schema title is visible.

This is a fix for #147.