### PR TITLE
Single example renders incorrectly due to .value use

### DIFF
--- a/openapi3.js
+++ b/openapi3.js
@@ -449,7 +449,7 @@ function getResponseExamples(data) {
                 }
             }
             else if (contentType.example) {
-                examples.push({description:resp+' '+data.translations.response,value:common.clean(convertExample(contentType.example.value)), cta: cta});
+                examples.push({description:resp+' '+data.translations.response,value:common.clean(convertExample(contentType.example)), cta: cta});
             }
             else if (contentType.schema) {
                 let obj = contentType.schema;


### PR DESCRIPTION
According to both [the spec](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#mediaTypeObject) and [this issue](https://github.com/OAI/OpenAPI-Specification/issues/1116), a single `example` in a media type contains the raw example data instead of an [Example Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#exampleObject). This means that accessing `.value` is incorrect behavior, and for example this will fail to produce any output by Widdershins:

```yaml
paths:
  /foo:
    get:
      responses:
        200:
          text/plain:
            example: 'hello, world'
```

This proposed change fixes the behavior, but note it will probably break things. You may want to add some kind of backward compatibility!