### PR TITLE
OpenAPI 3 doesn't use .value sub value on singular examples.

### DIFF
--- a/openapi3.js
+++ b/openapi3.js
@@ -449,7 +449,7 @@ function getResponseExamples(data) {
                 }
             }
             else if (contentType.example) {
-                examples.push({description:resp+' '+data.translations.response,value:common.clean(convertExample(contentType.example.value)), cta: cta});
+                examples.push({description:resp+' '+data.translations.response,value:common.clean(convertExample(contentType.example)), cta: cta});
             }
             else if (contentType.schema) {
                 let obj = contentType.schema;


### PR DESCRIPTION
Noticed the examples were null, went hunting, found this.