### PR TITLE
Fix nested entity depth issue

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -301,7 +301,8 @@ function schemaToArray(schema,offset,options,data) {
                 oDepth++;
             }
             if (state.depth < iDepth) {
-                oDepth--;
+                let difference = (iDepth - state.depth)/2;
+                oDepth -= difference;
                 if (oDepth<0) oDepth=0;
             }
             iDepth = state.depth;

--- a/lib/common.js
+++ b/lib/common.js
@@ -301,8 +301,15 @@ function schemaToArray(schema,offset,options,data) {
                 oDepth++;
             }
             if (state.depth < iDepth) {
-                let difference = (iDepth - state.depth)/2;
-                oDepth -= difference;
+                // when an array of objects occurs, the depth (state.depth or iDepth) of object attributes gets 
+                // inflated by 1 due to the array, but the oDepth only increases by 1 so having an attributes iDepth or state.depth
+                // be greater than the oDepth is valid. Having a state.depth or iDepth less than the oDepth is not valid though as the
+                // base state is having a state.depth or iDepth of 1 accompanied by an oDepth of 1. 
+                if (state.depth < oDepth) {
+                    oDepth = state.depth;
+                } else {
+                    oDepth--;
+                }
                 if (oDepth<0) oDepth=0;
             }
             iDepth = state.depth;

--- a/lib/common.js
+++ b/lib/common.js
@@ -216,6 +216,7 @@ function schemaToArray(schema,offset,options,data) {
     let blockDepth = 0;
     let skipDepth = -1;
     let container = [];
+    let depthQueue = new Map();
     let block = { title: '', rows: [] };
     if (schema) {
         if (schema.title) block.title = schema.title;
@@ -298,18 +299,24 @@ function schemaToArray(schema,offset,options,data) {
 
         if (entry.name) {
             if (state.depth > iDepth) {
+                let difference = state.depth - iDepth;
+                depthQueue.set(iDepth, difference);
                 oDepth++;
             }
             if (state.depth < iDepth) {
-                // when an array of objects occurs, the depth (state.depth or iDepth) of object attributes gets 
-                // inflated by 1 due to the array, but the oDepth only increases by 1 so having an attributes iDepth or state.depth
-                // be greater than the oDepth is valid. Having a state.depth or iDepth less than the oDepth is not valid though as the
-                // base state is having a state.depth or iDepth of 1 accompanied by an oDepth of 1. 
-                if (state.depth < oDepth) {
-                    oDepth = state.depth;
-                } else {
-                    oDepth--;
+                let keys = depthQueue.keys();
+                let next = keys.next();
+                let difference = 0;
+                while (!next.done) {
+                    if (next.value >= state.depth) {
+                        let depth = depthQueue.get(next.value);
+                        depth = depth % 2 == 0 ? depth/2 : depth;
+                        difference += depth;
+                        depthQueue.delete(next.value);
+                    }
+                    next = keys.next();
                 }
+                oDepth -= difference;
                 if (oDepth<0) oDepth=0;
             }
             iDepth = state.depth;


### PR DESCRIPTION
## Problem

I noticed that for an API I was working on that in the schema definitions the table was not showing sub-entities all at the correct level. Specifically, when we went from a doubly nested entity back to a parent entity, the table would still show the attribute at a nested level.

### Detailed description

In looking at the code, I found that it was doing a simple comparison of `iDepth` and `state.depth` in the `schemaToArray` function to decide whether to increase or decrease `oDepth`. If you turn on the [console.warn](https://github.com/Mermade/widdershins/blob/master/common.js#L286) in that same function, you can see that iDepth always increases or decreases by two, but `oDepth` was only ever increasing or decreasing by a one. The increasing by one makes sense since when traversing a definition, a sub entity only ever increases one level at a time; it doesn't make sense to suddenly be nested two levels without warning. But for decreasing, it makes less sense since it could be comparing a doubly, triply, or any other level of nesting with something on the parent definition if the sub entity definition is done. Knowing that `iDepth` always increases or decreases by two, we can simply take the difference between `iDepth` and `state.depth` and divide it by two to get what we should actually be taking away from `oDepth`.

## Open API specification example

If you use widdershins on the following example, you can see that the `description` attribute which should be on `postExamples` will show up in the schema definitions table as nested under `sub_examples`. Integrating my fix will correctly show `description` under the `postExamples` definition.

```json
{
  "info": {
    "title": "Example title",
    "description": "Example description.",
    "version": "v1"
  },
  "swagger": "2.0",
  "produces": [
    "application/xml",
    "application/json",
    "application/octet-stream",
    "text/plain"
  ],
  "host": "example.org",
  "basePath": "/example/v1",
  "schemes": [
    "https"
  ],
  "tags": [
    {
      "name": "examples",
      "description": "Operations about examples"
    }
  ],
  "paths": {
    "/examples": {
      "post": {
        "summary": "Create an example",
        "description": "Create an example using a POST request",
        "produces": [
          "application/json"
        ],
        "consumes": [
          "application/json"
        ],
        "parameters": [
          {
            "name": "Examples",
            "in": "body",
            "required": true,
            "schema": {
              "$ref": "#/definitions/postExamples"
            }
          }
        ],
        "responses": {
          "201": {
            "description": "Created"
          },
          "400": {
            "description": "Bad Request"
          }
        },
        "tags": [
          "examples"
        ],
        "operationId": "postExamples"
      }
    }
  },
  "definitions": {
    "postExamples": {
      "type": "object",
      "properties": {
        "id": {
          "type": "string"
        },
        "sub_examples": {
          "type": "array",
          "items": {
            "type": "object",
            "properties": {
              "id": {
                "type": "string"
              },
              "dub_sub_examples": {
                "type": "array",
                "items": {
                  "type": "object",
                  "properties": {
                    "id": {
                      "type": "string"
                    }
                  },
                  "required": [
                    "id"
                  ]
                }
              }
            },
            "required": [
              "id",
              "dub_sub_examples"
            ]
          }
        },
        "description": {
          "type": "string"
        }
      },
      "required": [
        "id",
        "sub_examples",
        "description"
      ],
      "description": "Create an example"
    }
  }
}
```