### PR TITLE
Remove extraneous newline from http code examples

### DIFF
--- a/openapi3.js
+++ b/openapi3.js
@@ -312,17 +312,17 @@ function getBodyParameterExamples(data) {
         content += safejson(obj,null,2) + '\n';
         content += '```\n\n';
     }
-    if (common.doContentType(data.consumes, 'yaml')) {
+    else if (common.doContentType(data.consumes, 'yaml')) {
         content += '```yaml\n';
         content += yaml.safeDump(obj) + '\n';
         content += '```\n\n';
     }
-    if (common.doContentType(data.consumes, 'form')) {
+    else if (common.doContentType(data.consumes, 'form')) {
         content += '```yaml\n';
         content += yaml.safeDump(obj) + '\n';
         content += '```\n\n';
     }
-    if (common.doContentType(data.consumes, 'xml') && (typeof obj === 'object')) {
+    else if (common.doContentType(data.consumes, 'xml') && (typeof obj === 'object')) {
         if (xmlWrap) {
             var newObj = {};
             newObj[xmlWrap] = obj;
@@ -330,6 +330,11 @@ function getBodyParameterExamples(data) {
         }
         content += '```xml\n';
         content += xml.getXml(JSON.parse(safejson(obj)), '@', '', true, '  ', false) + '\n';
+        content += '```\n\n';
+    }
+    else {
+        content += '```\n';
+        content += obj.value;
         content += '```\n\n';
     }
     return content;

--- a/templates/openapi3/code_http.dot
+++ b/templates/openapi3/code_http.dot
@@ -1,7 +1,7 @@
 {{=data.methodUpper}} {{=data.url}}{{=data.requiredQueryString}} HTTP/1.1
 {{? data.host}}Host: {{=data.host}}{{?}}
-{{?data.consumes.length}}Content-Type: {{=data.consumes[0]}}{{?}}
-{{?data.produces.length}}Accept: {{=data.produces[0]}}{{?}}
+{{?data.consumes.length}}Content-Type: {{=data.consumes[0]}}
+{{?}}{{?data.produces.length}}Accept: {{=data.produces[0]}}{{?}}
 {{?data.headerParameters.length}}{{~ data.headerParameters :p:index}}{{=p.name}}: {{=p.exampleValues.object}}
 {{~}}
 {{?}}


### PR DESCRIPTION
This patch removes an unnecessary newline in the http code example

![image](https://user-images.githubusercontent.com/32682246/43825490-ce9572b2-9aec-11e8-8519-bdf8447868cf.png)

