### PR TITLE
Remove extraneous newline from http code examples

### DIFF
--- a/templates/openapi3/code_http.dot
+++ b/templates/openapi3/code_http.dot
@@ -1,7 +1,7 @@
 {{=data.methodUpper}} {{=data.url}}{{=data.requiredQueryString}} HTTP/1.1
 {{? data.host}}Host: {{=data.host}}{{?}}
-{{?data.consumes.length}}Content-Type: {{=data.consumes[0]}}{{?}}
-{{?data.produces.length}}Accept: {{=data.produces[0]}}{{?}}
+{{?data.consumes.length}}Content-Type: {{=data.consumes[0]}}
+{{?}}{{?data.produces.length}}Accept: {{=data.produces[0]}}{{?}}
 {{?data.headerParameters.length}}{{~ data.headerParameters :p:index}}{{=p.name}}: {{=p.exampleValues.object}}
 {{~}}
 {{?}}


### PR DESCRIPTION
This patch removes an unnecessary newline in the http code example

![image](https://user-images.githubusercontent.com/32682246/43826011-1cf57f82-9aee-11e8-8dc3-cbd302bda84c.png)
