### PR TITLE
Add support for custom API key value

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ OpenAPI / Swagger / AsyncAPI / Semoasa definition to [Slate](https://github.com/
 
 ```
 node widdershins [options] {input-file|url} [[-o] output markdown]
+  --customApiKeyValue   Set a custom API key value                      [string]
   --expandBody          Expand requestBody properties in parameters    [boolean]
   --headings            Levels of headings to expand in TOC[number] [default: 2]
   --omitBody            Omit top-level fake body parameter object      [boolean]

--- a/openapi3.js
+++ b/openapi3.js
@@ -275,6 +275,9 @@ function getParameters(data) {
                     authHeader.isAuth = true;
                     authHeader.exampleValues = {};
                     authHeader.exampleValues.object = 'API_KEY';
+                    if (data.options.customApiKeyValue) {
+                        authHeader.exampleValues.object = data.options.customApiKeyValue;
+                    }
                     authHeader.exampleValues.json = "'" + authHeader.exampleValues.object + "'";
                     data.allHeaders.push(authHeader);
                 }

--- a/widdershins.js
+++ b/widdershins.js
@@ -17,6 +17,8 @@ var argv = require('yargs')
     .boolean('code')
     .alias('c','code')
     .describe('code','Turn generic code samples off')
+    .string('customApiKeyValue')
+    .describe('customApiKeyValue','Set a custom API key value')
     .string('includes')
     .boolean('discovery')
     .alias('d','discovery')
@@ -143,6 +145,7 @@ options.maxDepth = argv.maxDepth;
 options.omitBody = argv.omitBody;
 options.shallowSchemas = argv.shallowSchemas;
 options.yaml = argv.yaml;
+options.customApiKeyValue = argv.customApiKeyValue;
 if (argv.search === false) options.search = false;
 if (argv.includes) options.includes = argv.includes.split(',');
 


### PR DESCRIPTION
Our security part of the OpenAPI schema looks like this:
``` 
     security:
        - X-Api-Key: []
          X-Nonce: []
          X-Signature: []
```

Code samples are rendered with the _API_KEY_ value, which is not an appropriate value for `X-Nonce` and `X-Signature`:
```
curl ...
  -H 'X-Api-Key: API_KEY' \
  -H 'X-Nonce: API_KEY' \
  -H 'X-Signature: API_KEY'
```

This PR adds the ability to set, using the option `--customApiKeyValue VALUE`, a custom "API key" value, so the resulting code samples would be:
```
curl ...
  -H 'X-Api-Key: VALUE' \
  -H 'X-Nonce: VALUE' \
  -H 'X-Signature: VALUE'
```