### PR TITLE
Update javascript template for openapi3

### DIFF
--- a/templates/openapi3/code_javascript.dot
+++ b/templates/openapi3/code_javascript.dot
@@ -1,14 +1,17 @@
-{{?data.allHeaders.length}}var headers = {
+{{?data.bodyParameter.present}}const inputBody = '{{=data.bodyParameter.exampleValues.json}}';{{?}}
+{{?data.allHeaders.length}}const headers = {
 {{~data.allHeaders :p:index}}  '{{=p.name}}':{{=p.exampleValues.json}}{{?index < data.allHeaders.length-1}},{{?}}
 {{~}}
 };
 {{?}}
-$.ajax({
-  url: '{{=data.url}}',
-  method: '{{=data.method.verb}}',
-{{?data.requiredQueryString}}  data: '{{=data.requiredQueryString}}',{{?}}
-{{?data.allHeaders.length}}  headers: headers,{{?}}
-  success: function(data) {
-    console.log(JSON.stringify(data));
-  }
+fetch('{{=data.url}}{{=data.requiredQueryString}}',
+{
+  method: '{{=data.methodUpper}}'{{?data.bodyParameter.present || data.allHeaders.length}},{{?}}
+{{?data.bodyParameter.present}}  body: inputBody{{?}}{{? data.bodyParameter.present && data.allHeaders.length}},{{?}}
+{{?data.allHeaders.length}}  headers: headers{{?}}
 })
+.then(function(res) {
+    return res.json();
+}).then(function(body) {
+    console.log(body);
+});


### PR DESCRIPTION
The `$.ajax` method is not JavaScript, is a part of the jQuery library.

Using real modern JavaScript method instead of using jQuery will be better.

Cause the nodejs example use `node-fetch` package that consistent with `window.fetch` API, I copied the code from the nodejs example to that example. 