### PR TITLE
Update oas-schema-walker dependency and use allowRefSiblings for refs

### DIFF
--- a/common.js
+++ b/common.js
@@ -205,6 +205,7 @@ function schemaToArray(schema,offset,options,data) {
     container.push(block);
     let wsState = wsGetState();
     wsState.combine = true;
+    wsState.allowRefSiblings = true;
     walkSchema(schema,{},wsState,function(schema,parent,state){
 
         let isBlock = false;

--- a/package-lock.json
+++ b/package-lock.json
@@ -553,9 +553,9 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "jgexml": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/jgexml/-/jgexml-0.3.8.tgz",
-      "integrity": "sha512-WKxxkEInMFCnUXk6QpCQWMVyUEgiasTeP9TLbMvPoaTq5Wvf0bG+w7k5Fn3QQ8GOqUJHcHUGw/kQiYEBXR7xyQ=="
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/jgexml/-/jgexml-0.3.9.tgz",
+      "integrity": "sha512-OiucENxrgrQ0HgBhb0LewMeubJsOdKwoauSJsSk0eXBnXupW+RmeGvAcC5agdFw+V5f+OAIwmgvutOQAwnPZfw=="
     },
     "js-tokens": {
       "version": "3.0.2",
@@ -821,9 +821,9 @@
       }
     },
     "oas-schema-walker": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/oas-schema-walker/-/oas-schema-walker-1.0.3.tgz",
-      "integrity": "sha512-D/NMFkzhGjvOO5oKNW7MeAvCyL9Dtjvc/0RUAZa1+7rh1QYp97JxKezMB12zrTNoxlyLdnMhjke16rlv8MD8sg=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/oas-schema-walker/-/oas-schema-walker-1.1.0.tgz",
+      "integrity": "sha512-f1K+o/Ef1eNf3Iw4VP4WOnIajFc45A0goid8Dpb+Cgq2VbnYj6aaUxN5LL7XPPhleWgSMnU+DB8yMGVHJf8mBw=="
     },
     "oas-validator": {
       "version": "1.0.1",
@@ -836,7 +836,7 @@
         "oas-kit-common": "1.0.0",
         "oas-linter": "1.0.0",
         "oas-resolver": "1.0.1",
-        "oas-schema-walker": "1.0.3",
+        "oas-schema-walker": "1.1.0",
         "reftools": "1.0.0",
         "should": "13.2.1"
       }
@@ -1123,7 +1123,7 @@
         "node-readfiles": "0.2.0",
         "oas-kit-common": "1.0.0",
         "oas-resolver": "1.0.1",
-        "oas-schema-walker": "1.0.3",
+        "oas-schema-walker": "1.1.0",
         "oas-validator": "1.0.1",
         "reftools": "1.0.0",
         "yargs": "11.1.0"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "js-yaml": "^3.6.1",
     "node-fetch": "^2.0.0",
     "oas-resolver": "^1.0.1",
-    "oas-schema-walker": "^1.0.3",
+    "oas-schema-walker": "^1.1.0",
     "openapi-sampler": "^1.0.0-beta.9",
     "reftools": "^1.0.0",
     "safe-json-stringify": "^1.2.0",

--- a/testRunner.js
+++ b/testRunner.js
@@ -130,7 +130,7 @@ function* check(file) {
                 result = result.split('|undefined|').join('x');
                 result = result.split('efault: undefined').join('x');
                 result = result.split('"undefined",').join('x');
-                result = result.split('undefined,').join('x');
+                result = result.split('and undefined,').join('x');
                 if (ok && result.indexOf('undefined')>=0) {
                     message = 'Ok except for undefined references';
                     ok = false;

--- a/testRunner.js
+++ b/testRunner.js
@@ -130,6 +130,7 @@ function* check(file) {
                 result = result.split('|undefined|').join('x');
                 result = result.split('efault: undefined').join('x');
                 result = result.split('"undefined",').join('x');
+                result = result.split('undefined,').join('x');
                 if (ok && result.indexOf('undefined')>=0) {
                     message = 'Ok except for undefined references';
                     ok = false;


### PR DESCRIPTION
Relates to [oas-kit #81](https://github.com/Mermade/oas-kit/pull/81).

Use new attribute `allowRefSibling` so that singular references in schema definitions can have descriptions.