### PR TITLE
Fixes incorrect handling of disabling security on specific operations

### DIFF
--- a/openapi3.js
+++ b/openapi3.js
@@ -245,8 +245,10 @@ function getParameters(data) {
     let existingAuth = data.allHeaders.find(function(e,i,a){
         return e.name.toLowerCase() === 'authorization';
     });
-    if (data.operation.security && data.operation.security.length) {
-        effSecurity = Object.keys(data.operation.security[0]);
+    if (data.operation.security) {
+        if(data.operation.security.length) {
+            effSecurity = Object.keys(data.operation.security[0]);
+        }
     }
     else if (data.api.security && data.api.security.length) {
         effSecurity = Object.keys(data.api.security[0]);

--- a/openapi3.js
+++ b/openapi3.js
@@ -246,7 +246,7 @@ function getParameters(data) {
         return e.name.toLowerCase() === 'authorization';
     });
     if (data.operation.security) {
-        if(data.operation.security.length) {
+        if (data.operation.security.length) {
             effSecurity = Object.keys(data.operation.security[0]);
         }
     }


### PR DESCRIPTION
Without this modification authentication header is still included in code samples on operations with disabled security.

An example on an operation with no security enabled under code samples;
```
# You can also use wget
curl -X GET URL_HERE \
  -H 'Accept: application/json' \
  -H 'Authorization: Bearer {access-token}'
```
Is still there. It should not be included.

Expected result;
```
# You can also use wget
curl -X GET URL_HERE \
  -H 'Accept: application/json'
```

This pull request fixes this behavior.