### PR TITLE
Fix title prefix in headers

### DIFF
--- a/openapi3.js
+++ b/openapi3.js
@@ -612,7 +612,7 @@ function convertInner(api, options, callback) {
 
     data.options = options;
     data.header = header;
-    data.title_prefix = (data.api.info && data.api.info.version ? (data.api.info.title.trim()||'API').split(' ').join('-') : '');
+    data.title_prefix = (data.api.info && data.api.info.version ? (data.api.info.title.trim()||'API').split(/[\s\.]/).join('-') : '');
     data.templates = templates;
     data.resources = convertToToc(api,data);
 


### PR DESCRIPTION
Literal dots in the title are left in the title_prefix for headers.
This causes issues when rendering the markdown.

This fix replaces literal dot with '-'