### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "homepage": "https://github.com/Mermade/widdershins#readme",
   "dependencies": {
     "dot": "^1.0.3",
-    "httpsnippet": "1.16.5",
+    "httpsnippet": "1.16.6",
     "jgexml": "latest",
     "js-yaml": "^3.6.1",
     "node-fetch": "^2.0.0",


### PR DESCRIPTION
Modify to new version of httpsnippet that no longer has the vulnerability version of event-stream as dependency.

More information here: https://github.com/dominictarr/event-stream/issues/116