### PR TITLE
Changed column heading from `Parameter` to `Name`

### DIFF
--- a/templates/openapi3/parameters.def
+++ b/templates/openapi3/parameters.def
@@ -1,6 +1,6 @@
 <h3 id="{{=data.operationUniqueSlug}}-parameters">Parameters</h3>
 
-|Parameter|In|Type|Required|Description|
+|Name|In|Type|Required|Description|
 |---|---|---|---|---|
 {{~ data.parameters :p}}|{{=p.name}}|{{=p.in}}|{{=p.safeType}}|{{=p.required}}|{{=p.shortDesc || 'none'}}|
 {{~}}


### PR DESCRIPTION
 - Swagger Editor follows the same convention. It uses `Name` heading for the Parameters section.
 - Because heading `Parameters` followed by a table column `Parameter` doesn't look good.

![image](https://user-images.githubusercontent.com/23069445/49777896-241da880-fd4e-11e8-8b0d-76c048d2e6ba.png)
