### PR TITLE
Support text/html responses

### DIFF
--- a/common.js
+++ b/common.js
@@ -19,7 +19,8 @@ const contentTypes = {
     xml: ['^(application|text|image){1}\\/(.*\\+){0,1}xml(;){0,1}(\\s){0,}(charset=.*){0,}$'],
     json: ['^(application|text){1}\\/(.*\\+){0,1}json(;){0,1}(\\s){0,}(charset=.*){0,}$'],
     yaml: ['application/x-yaml', 'text/x-yaml'],
-    form: ['multipart/form-data', 'application/x-www-form-urlencoded', 'application/octet-stream']
+    form: ['multipart/form-data', 'application/x-www-form-urlencoded', 'application/octet-stream'],
+    text: ['text/plain', 'text/html']
 };
 
 function nop(obj) {

--- a/openapi3.js
+++ b/openapi3.js
@@ -324,7 +324,7 @@ function getBodyParameterExamples(data) {
     }
     if (common.doContentType(data.consumes, 'text')) {
         content += '```\n';
-        content += example.value + '\n';
+        content += yaml.safeDump(obj) + '\n';
         content += '```\n\n';
     }
     if (common.doContentType(data.consumes, 'form')) {

--- a/openapi3.js
+++ b/openapi3.js
@@ -501,7 +501,7 @@ function getResponseExamples(data) {
         }
         if (common.doContentType(example.cta, 'text')) {
             content += '```\n';
-            content += example.value + '\n';
+            content += JSON.stringify(example.value) + '\n';
             content += '```\n\n';
         }
         let xmlObj = example.value;

--- a/openapi3.js
+++ b/openapi3.js
@@ -322,6 +322,11 @@ function getBodyParameterExamples(data) {
         content += yaml.safeDump(obj) + '\n';
         content += '```\n\n';
     }
+    if (common.doContentType(example.cta, 'text')) {
+        content += '```\n';
+        content += example.value + '\n';
+        content += '```\n\n';
+    }
     if (common.doContentType(data.consumes, 'form')) {
         content += '```yaml\n';
         content += yaml.safeDump(obj) + '\n';
@@ -462,6 +467,7 @@ function getResponseExamples(data) {
                 if (common.doContentType(cta, 'json')) autoCT = 'json';
                 if (common.doContentType(cta, 'yaml')) autoCT = 'yaml';
                 if (common.doContentType(cta, 'xml'))  autoCT = 'xml';
+                if (common.doContentType(cta, 'text')) autoCT = 'text';
 
                 if (!autoDone[autoCT]) {
                     autoDone[autoCT] = true;
@@ -491,6 +497,11 @@ function getResponseExamples(data) {
         if (common.doContentType(example.cta, 'yaml')) {
             content += '```yaml\n';
             content += yaml.safeDump(example.value) + '\n';
+            content += '```\n\n';
+        }
+        if (common.doContentType(example.cta, 'text')) {
+            content += '```\n';
+            content += example.value + '\n';
             content += '```\n\n';
         }
         let xmlObj = example.value;

--- a/openapi3.js
+++ b/openapi3.js
@@ -322,7 +322,7 @@ function getBodyParameterExamples(data) {
         content += yaml.safeDump(obj) + '\n';
         content += '```\n\n';
     }
-    if (common.doContentType(example.cta, 'text')) {
+    if (common.doContentType(data.consumes, 'text')) {
         content += '```\n';
         content += example.value + '\n';
         content += '```\n\n';

--- a/test/contentType.test.js
+++ b/test/contentType.test.js
@@ -119,7 +119,7 @@ describe('array tests',function(){
         assert(!common.doContentType([],'json'));
     });
     it('should not match an unknown format',function(){
-        assert(!common.doContentType(['text/plain'],'text'));
+        assert(!common.doContentType(['application/octet-stream'],'file'));
     });
   });
 });

--- a/testRunner.js
+++ b/testRunner.js
@@ -133,7 +133,7 @@ function* check(file) {
                 result = result.split('": "undefined"').join('x');
                 result = result.split('"undefined",').join('x');
                 result = result.split('and undefined,').join('x');
-                result = result.split('otherwise undefined').join('x');
+                result = result.split('otherwise undefined.').join('x');
                 if (ok && result.indexOf('undefined')>=0) {
                     message = 'Ok except for undefined references';
                     ok = false;

--- a/testRunner.js
+++ b/testRunner.js
@@ -133,7 +133,7 @@ function* check(file) {
                 result = result.split('": "undefined"').join('x');
                 result = result.split('"undefined",').join('x');
                 result = result.split('and undefined,').join('x');
-                result = result.split('otherwise undefined.').join('x');
+                result = result.split('otherwise undefined').join('x');
                 if (ok && result.indexOf('undefined')>=0) {
                     message = 'Ok except for undefined references';
                     ok = false;

--- a/testRunner.js
+++ b/testRunner.js
@@ -118,7 +118,7 @@ function* check(file) {
                 let message = '';
                 if (!result) result = '';
                 result = result.split('is undefined').join('x');
-                result = result.split('f undefined').join('x');
+                result = result.split('If undefined').join('x');
                 result = result.split('are undefined').join('x');
                 result = result.split('be undefined').join('x');
                 result = result.split('undefined to').join('x');

--- a/testRunner.js
+++ b/testRunner.js
@@ -118,7 +118,7 @@ function* check(file) {
                 let message = '';
                 if (!result) result = '';
                 result = result.split('is undefined').join('x');
-                result = result.split('If undefined').join('x');
+                result = result.split('f undefined').join('x');
                 result = result.split('are undefined').join('x');
                 result = result.split('be undefined').join('x');
                 result = result.split('undefined to').join('x');


### PR DESCRIPTION
I've got endpoints that return text/html, so the openapi 3 doc looks like this:
```
"responses": {
    "200": {
        "description": "successful operation",
        "content": {
          "text/html": {
            "schema": {
              "$ref": "#/components/schemas/TextResponse"
            },
            "examples": {
              "default": {
                "description": "Example text response",
                "value": "Here is a sample text response value"
              }
            }
          }
        }
    },
```
Could we add support for text/html to widdershins? This PR makes it work with this sample OAS3 doc:
https://gist.github.com/timothymcmackin/2c0b30df8e095bcada630443af98c72c