### PR TITLE
fixes #220 - Only list unique operation produces media types 

### DIFF
--- a/lib/openapi3.js
+++ b/lib/openapi3.js
@@ -84,7 +84,9 @@ function fakeProdCons(data) {
     for (var r in data.operation.responses) {
         var response = data.operation.responses[r];
         for (var prod in response.content) {
-            data.produces.push(prod);
+            if (! data.produces.includes(prod)) {
+              data.produces.push(prod);
+            }
         }
     }
     let op = data.method.operation;


### PR DESCRIPTION
When iterating over all responses, only add a media type if it
is not already in the operation.produces