### PR TITLE
update template naming to naming actually used by asyncapi spec

### DIFF
--- a/templates/asyncapi1/main.dot
+++ b/templates/asyncapi1/main.dot
@@ -106,11 +106,11 @@ Delimiter: {{= data.api.stream.framing.delimiter||'\r\n'}}
 {{?}}
 
 {{? data.api.events }}
-# Evented API
-{{ data.topicName = 'evented'; }}
+# Events API
+{{ data.topicName = 'events'; }}
 
 {{? data.api.events.receive }}
-## Received
+## Receive
 {{~ data.api.events.receive :r }}
 {{ data.messageName = ''; }}
 {{ data.message = r; }}
@@ -119,7 +119,7 @@ Delimiter: {{= data.api.stream.framing.delimiter||'\r\n'}}
 {{?}}
 
 {{? data.api.events.send }}
-## Sent
+## Send
 {{~ data.api.events.send :s }}
 {{ data.messageName = ''; }}
 {{ data.message = s; }}


### PR DESCRIPTION
The naming in the template doesn't match the naming of the actual specification. I think having it the same should be the case for the default template.