### PR TITLE
add support for `--headings` in AsyncAPI 1.x

### DIFF
--- a/lib/asyncapi1.js
+++ b/lib/asyncapi1.js
@@ -69,7 +69,7 @@ function convertInner(api, options, callback) {
     header.title = api.info && api.info.title ? ' ' + data.version : ' 1.0.0';
 
     header.language_tabs = options.language_tabs;
-    header.headingLevel = 3;
+    header.headingLevel = options.headings || 3;
 
     header.toc_footers = [];
     if (api.externalDocs) {


### PR DESCRIPTION
A fix for this issue:

**AsyncAPI doesn't adhere `--headings` parameter https://github.com/Mermade/widdershins/issues/228**

It will break default behaviour of AsyncAPI `headingsLevel=3` because it is defined as default 2 in execution argument parser.