### PR TITLE
extend options to support adding toc_footers

### DIFF
--- a/lib/asyncapi1.js
+++ b/lib/asyncapi1.js
@@ -77,6 +77,11 @@ function convertInner(api, options, callback) {
             header.toc_footers.push('<a href="' + api.externalDocs.url + '">' + (api.externalDocs.description ? api.externalDocs.description : 'External Docs') + '</a>');
         }
     }
+    if ( options.toc_footers ) {
+        for ( var key in options.toc_footers ) {
+            header.toc_footers.push('<a href="' + options.toc_footers[key].url + '">' + options.toc_footers[key].description + '</a>');
+        }
+    }
     header.includes = options.includes;
     header.search = options.search;
     header.highlight_theme = options.theme;

--- a/lib/openapi3.js
+++ b/lib/openapi3.js
@@ -625,8 +625,8 @@ function convertInner(api, options, callback) {
         }
     }
     if ( options.toc_footers ) {
-        for ( key in options.toc_footers ) {
-            header.toc_footers.push('<a href="' + options.toc_footers[key].url + '">' + toc_footers[key].description + '</a>');
+        for ( var key in options.toc_footers ) {
+            header.toc_footers.push('<a href="' + options.toc_footers[key].url + '">' + options.toc_footers[key].description + '</a>');
         }
     }
     header.includes = options.includes;

--- a/lib/openapi3.js
+++ b/lib/openapi3.js
@@ -624,6 +624,11 @@ function convertInner(api, options, callback) {
             header.toc_footers.push('<a href="' + api.externalDocs.url + '">' + (api.externalDocs.description ? api.externalDocs.description : data.translations.externalDocs) + '</a>');
         }
     }
+    if ( options.toc_footers ) {
+        for ( key in options.toc_footers ) {
+            header.toc_footers.push('<a href="' + options.toc_footers[key].url + '">' + toc_footers[key].description + '</a>');
+        }
+    }
     header.includes = options.includes;
     header.search = options.search;
     header.highlight_theme = options.theme;

--- a/lib/semoasa.js
+++ b/lib/semoasa.js
@@ -39,6 +39,11 @@ function convert(api, options, callback) {
             header.toc_footers.push('<a href="' + api.externalDocs.url + '">' + (api.externalDocs.description ? api.externalDocs.description : 'External Docs') + '</a>');
         }
     }
+    if ( options.toc_footers ) {
+        for ( var key in options.toc_footers ) {
+            header.toc_footers.push('<a href="' + options.toc_footers[key].url + '">' + options.toc_footers[key].description + '</a>');
+        }
+    }
     header.includes = options.includes;
     header.search = options.search;
     header.highlight_theme = options.theme;


### PR DESCRIPTION
hi, i wanted to add toc_footers from configuration which wasn't supported as far as i can tell.

```node
...
options.toc_footers = [
    { 'url': 'mailto:brian@fake.com', 'description': 'Sign Up for a Developer Key' },
    { 'url': 'https://fake.com/about', 'description': 'Learn more about Fake.com' }
];
...
converter.convert(api, options, function(err,str) {
    // str contains the converted markdown
    console.log(str);
    fs.writeFile(outputFileName, str, (err) => {  
        // throws an error, you could also catch it here
        if (err) throw err;
    });
});
```