### PR TITLE
Python template improvements

### DIFF
--- a/templates/openapi3/code_python.dot
+++ b/templates/openapi3/code_python.dot
@@ -3,8 +3,8 @@ import requests
 {{~data.allHeaders :p:index}}  '{{=p.name}}': {{=p.exampleValues.json}}{{?index < data.allHeaders.length-1}},{{?}}
 {{~}}}
 {{?}}
-r = requests.{{=data.method.verb}}('{{=data.url}}', params={
+r = requests.{{=data.method.verb}}('{{=data.url}}'{{? data.requiredParameters.length}}, params={
 {{~ data.requiredParameters :p:index}}  '{{=p.name}}': {{=p.exampleValues.json}}{{? data.requiredParameters.length-1 != index }},{{?}}{{~}}
-}{{?data.allHeaders.length}}, headers = headers{{?}})
+}{{?}}{{?data.allHeaders.length}}, headers = headers{{?}})
 
 print r.json()

--- a/templates/openapi3/code_python.dot
+++ b/templates/openapi3/code_python.dot
@@ -5,6 +5,6 @@ import requests
 {{?}}
 r = requests.{{=data.method.verb}}('{{=data.url}}', params={
 {{~ data.requiredParameters :p:index}}  '{{=p.name}}': {{=p.exampleValues.json}}{{? data.requiredParameters.length-1 != index }},{{?}}{{~}}
-{{?data.allHeaders.length}}}, headers = headers{{?}})
+}{{?data.allHeaders.length}}, headers = headers{{?}})
 
 print r.json()


### PR DESCRIPTION
If you look at the commits individually should be pretty easy to see what's going on. Obviously there are a lot of curly braces, which was the cause of the original bug.

Previously, if you didn't set a header (i.e. no auth scheme), the code generated was missing the closing `}`. I've fixed that in the first commit.

In the second commit I omit empty params arrays.

Thanks for your great work on this project, sorry I don't have time to write this up in any more detail.