### PR TITLE
Add Shotstack to in the wild list

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ Please feel free to add a link to your API documentation here.
 * [Split Payments API](http://docs.split.cash/)
 * [LeApp daemon API](https://leapp-to.github.io/shins/index.html)
 * [Shutterstock API](https://api-reference.shutterstock.com/)
+* [Shotstack Video Editing API](https://shotstack.io/docs/api/index.html)
 
 ### Widdershins and Shins
 


### PR DESCRIPTION
We have used Widdershins and Shins to create a customised look and feel to our API reference docs. We've open sourced our setup here: https://github.com/shotstack/oas-api-definition

Hope you can add us to the list and share our our integration if it helps others.