### PR TITLE
Correct line numbering and indentation in these docs

### DIFF
--- a/docs/ConvertingFilesBasicCLI.md
+++ b/docs/ConvertingFilesBasicCLI.md
@@ -10,9 +10,9 @@ See [nodejs.org](https://nodejs.org/).
 - Install Widdershins and its dependencies.
 The easiest way is to use NPM to install Widdershins globally so you can use it with the command line from any folder.
 From a terminal window, run this command:
-```shell
-npm install -g widdershins
-```
+    ```shell
+    npm install -g widdershins
+    ```
 
 ## Converting files on the command line
 
@@ -22,24 +22,26 @@ The file must parse as a valid OpenAPI or Swagger file.
 1. Assemble the options that you want to use to convert the file.
 These options are listed in the [README.md](https://github.com/Mermade/widdershins#options) file.
 
-  Note that some of these options are useful only if you intend to take the Markdown output from Widdershins and convert it to HTML with [Shins](https://github.com/Mermade/shins).
-  Other options are not usable from the command line.
+    Note that some of these options are useful only if you intend to take the Markdown output from Widdershins and convert it to HTML with [Shins](https://github.com/Mermade/shins).
+    Other options are not usable from the command line.
 
-  For example, the `language_tabs` option specifies a list of one or more languages to generate examples in, each with an ID and display name.
-  You can generate examples in Ruby and Python with the command-line option `--language_tabs 'ruby:Ruby' 'python:Python'`.
+    For example, the `language_tabs` option specifies a list of one or more languages to generate examples in, each with an ID and display name.
+    You can generate examples in Ruby and Python with the command-line option `--language_tabs 'ruby:Ruby' 'python:Python'`.
 1. Optional: Put the options in an environment file for easier reuse.
 Environment files contain the options for the conversion in JSON format.
 For environment files, use the JavaScript parameter name from the [README.md](https://github.com/Mermade/widdershins#options) file, not the CLI parameter name.
 For example:
-```json
-{
-"language_tabs": [{ "python": "Python" }, { "ruby": "Ruby" }]
-}
-```
+
+    ```json
+    {
+      "language_tabs": [{ "python": "Python" }, { "ruby": "Ruby" }]
+    }
+    ```
 1. Convert the file with the `widdershins` command, specify the name of the OpenAPI or Swagger file, and specify the name of the output file with the `-o` option.
 Include the options in the command or specify the name of the environment file with the `--environment` option, as in this example:
-```shell
-widdershins --environment env.json swagger.json -o myOutput.md
-```
+
+    ```shell
+    widdershins --environment env.json swagger.json -o myOutput.md
+    ```
 
 Now you can use the Markdown file in your documentation or use a tool such as Shins to convert it to HTML.

--- a/docs/ConvertingFilesBasicJS.md
+++ b/docs/ConvertingFilesBasicJS.md
@@ -11,9 +11,9 @@ See [nodejs.org](https://nodejs.org/).
 NPM walks you through the process of setting up an NPM project and creates a `package.json` file to store the project configuration.
 Most of the NPM settings are not relevant to Widdershins; the important part of the process is that it sets up a project that can install and manage NPM packages such as Widdershins so you can use those packages in your programs.
 - From the root folder of your project (the folder that contains the `package.json` file), add Widdershins as a dependency by running this command:
-```shell
-npm install --save widdershins
-```
+    ```shell
+    npm install --save widdershins
+    ```
 
 Now you can use Widdershins in JavaScript programs in the project.
 
@@ -22,42 +22,48 @@ Now you can use Widdershins in JavaScript programs in the project.
 1. Create a JavaScript program with the following general steps.
 You can name the file anything you want.
 1. In the JavaScript file, import Widdershins so you can use it in the program:
-```javascript
-const widdershins = require('widdershins');
-```
+
+    ```javascript
+    const widdershins = require('widdershins');
+    ```
 1. Set up your options in an `options` object.
 Use the JavaScript parameter name from the [README.md](https://github.com/Mermade/widdershins#options) file, not the CLI parameter name.
 For example, these options generate code samples in Python and Ruby:
-```javascript
-const options = {
-  language_tabs: [{ python: "Python" }, { ruby: "Ruby" }]
-};
-```
+
+    ```javascript
+    const options = {
+      language_tabs: [{ python: "Python" }, { ruby: "Ruby" }]
+    };
+    ```
 1. Import and parse the OpenAPI or Swagger file.
 This example uses the NodeJS FileSystem and JSON packages:
-```javascript
-const fs = require('fs');
-const fileData = fs.readFileSync('swagger.json', 'utf8');
-const swaggerFile = JSON.parse(fileData);
-```
+
+    ```javascript
+    const fs = require('fs');
+    const fileData = fs.readFileSync('swagger.json', 'utf8');
+    const swaggerFile = JSON.parse(fileData);
+    ```
 1. Use Widdershins to convert the file.
 Widdershins returns the converted Markdown in a callback function:
-```javascript
-widdershins.convert(swaggerFile, options, function(err, markdownOutput) {
-  // markdownOutput contains the converted markdown
-});
-```
+
+    ```javascript
+    widdershins.convert(swaggerFile, options, function(err, markdownOutput) {
+      // markdownOutput contains the converted markdown
+    });
+    ```
 1. Within the callback function, write the Markdown to a file:
-```javascript
-widdershins.convert(swaggerFile, options, function(err, markdownOutput) {
-  // markdownOutput contains the converted markdown
-  fs.writeFileSync('myOutput.md', markdownOutput, 'utf8');
-});
-```
+
+    ```javascript
+    widdershins.convert(swaggerFile, options, function(err, markdownOutput) {
+      // markdownOutput contains the converted markdown
+      fs.writeFileSync('myOutput.md', markdownOutput, 'utf8');
+    });
+    ```
 1. Run the JavaScript program:
-```shell
-node convertMarkdown.js
-```
+
+    ```shell
+    node convertMarkdown.js
+    ```
 
 The complete JavaScript program looks like this:
 


### PR DESCRIPTION
The ordered lists get reset on these pages because the indentation is off. This PR fixes them so in the github online view they don't look like this:
![image](https://user-images.githubusercontent.com/6494785/69154268-ae69a300-0aad-11ea-8ceb-a837d10ae68e.png)
