### PR TITLE
Use Python3 Syntax for print()

### DIFF
--- a/templates/openapi3/code_python.dot
+++ b/templates/openapi3/code_python.dot
@@ -7,4 +7,4 @@ r = requests.{{=data.method.verb}}('{{=data.url}}'{{? data.requiredParameters.le
 {{~ data.requiredParameters :p:index}}  '{{=p.name}}': {{=p.exampleValues.json}}{{? data.requiredParameters.length-1 != index }},{{?}}{{~}}
 }{{?}}{{?data.allHeaders.length}}, headers = headers{{?}})
 
-print r.json()
+print(r.json())


### PR DESCRIPTION
The sample code produced should output Python 3 compatible code. Python 2 will be EOL in 2020.