### PR TITLE
Add support for multiple tags

### DIFF
--- a/lib/openapi3.js
+++ b/lib/openapi3.js
@@ -44,18 +44,18 @@ function convertToToc(source,data) {
                     sMethodUniqueName = method.operation.summary;
                 }
                 method.slug = sMethodUniqueName.toLowerCase().split(' ').join('-'); // TODO {, } and : ?
-                var tagName = data.translations.defaultTag;
-                var tagDescription = '';
-                if (method.operation.tags && method.operation.tags.length > 0) {
-                    var tagData = getTagGroup(method.operation.tags[0], data.options.tagGroups);
-                    tagName = tagData.name;
-                    tagDescription = tagData.description;
+                if (typeof method.operation.tags === 'undefined' || !method.operation.tags.length) {
+                    method.operation.tags = [data.translations.defaultTag];
                 }
-                if (!resources[tagName]) {
-                    resources[tagName] = { count: 0, methods: {}, description: tagDescription};
-                }
-                resources[tagName].count++;
-                resources[tagName].methods[sMethodUniqueName] = method;
+                method.operation.tags.forEach(function(tag){
+                    const tagData = getTagGroup(tag, data.options.tagGroups);
+                    const tagName = tagData.name;
+                    if (!resources[tagName]) {
+                        resources[tagName] = { count: 0, methods: {}, description: tagData.description };
+                    }
+                    resources[tagName].count++;
+                    resources[tagName].methods[sMethodUniqueName] = method;
+                });
             }
         }
     }


### PR DESCRIPTION
Currently, when an operation is assigned to multiple tags, widdershins uses only the first tag and ignores the rest. This PR fixes this incorrect behaviour and makes it use all defined tags.

Fixes issue https://github.com/Mermade/widdershins/issues/296