### PR TITLE
Handle openapi3 empty OAuth2 flow scopes

### DIFF
--- a/templates/openapi3/security.def
+++ b/templates/openapi3/security.def
@@ -18,7 +18,7 @@
     - Flow: {{=f}}
 {{? flow.authorizationUrl}}    - Authorization URL = [{{=flow.authorizationUrl}}]({{=flow.authorizationUrl}}){{?}}
 {{? flow.tokenUrl}}    - Token URL = [{{=flow.tokenUrl}}]({{=flow.tokenUrl}}){{?}}
-{{? flow.scopes}}
+{{? flow.scopes && Object.keys(flow.scopes).length}}
 |Scope|Scope Description|
 |---|---|
 {{ for (var sc in flow.scopes) { }}|{{=sc}}|{{=data.utils.join(flow.scopes[sc])}}|


### PR DESCRIPTION
Currently, the template in OpenAPI 3 for OAuth2 `flow.scopes` only
checks if `flow.scopes` exists, not whether or not it is empty.

The scopes object of an OpenAPI 3.0 flow object must exist
(if we're strictly following the spec/linter), but it can be empty:
<https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#oauth-flow-object>

Currently, we can get an empty scope table with no content, e.g.

|Scope|Scope Description|
|---|---|