### PR TITLE
Remove URI components from install cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ OpenAPI / Swagger / AsyncAPI / Semoasa definition to [Slate](https://github.com/
 ### To install
 
 * Clone the git repository, and `npm i` to install dependencies, or
-* `npm install [-g] widdershins` to install globally
+* `npm install -g widdershins` to install globally
 
 ### Getting started
 


### PR DESCRIPTION
When I tried to run the install command on the readme, I received this error: `npm ERR! code EINVALIDTAGNAME
npm ERR! Invalid tag name "[-g]": Tags may not have any characters that encodeURIComponent encodes.`. 

I removed the brackets so that the command works.