### PR TITLE
Add basicAuth auth header to all headers

### DIFF
--- a/lib/openapi3.js
+++ b/lib/openapi3.js
@@ -276,14 +276,15 @@ function getParameters(data) {
             if (data.api.components.securitySchemes[ess]) {
                 let secScheme = data.api.components.securitySchemes[ess];
                 if (!existingAuth && ((secScheme.type === 'oauth2') || (secScheme.type === 'openIdConnect') ||
-                    ((secScheme.type === 'http') && (secScheme.scheme === 'bearer')))) {
+                    ((secScheme.type === 'http') && ((secScheme.scheme === 'bearer') || (secScheme.scheme === 'basic'))))) {
+                    let method = secScheme.scheme === 'basic' ? 'Basic' : 'Bearer';
                     let authHeader = {};
                     authHeader.name = 'Authorization';
                     authHeader.type = 'string';
                     authHeader.in = 'header';
                     authHeader.isAuth = true;
                     authHeader.exampleValues = {};
-                    authHeader.exampleValues.object = 'Bearer {access-token}';
+                    authHeader.exampleValues.object = method + ' {access-token}';
                     authHeader.exampleValues.json = "'" + authHeader.exampleValues.object + "'";
                     data.allHeaders.push(authHeader);
                 }


### PR DESCRIPTION
Fixes #353

Although I haven't written any tests for this change, I have manually tested it using the [spec defined here](https://gist.github.com/badsyntax/c2eb92b3660bdce3da6186615e20939b), and it correctly generates the following code:

```shell
# You can also use wget
curl -X POST /example \
  -H 'Accept: text/html' \
  -H 'Authorization: Basic {access-token}'
```