### PR TITLE
Add a line break in between auth details and description

### DIFF
--- a/templates/openapi3/security.def
+++ b/templates/openapi3/security.def
@@ -9,7 +9,7 @@
     - Parameter Name: **{{=sd.name}}**, in: {{=sd.in}}. {{=sd.description || ''}}
 {{?}}
 {{? sd.type == 'http'}}
-- HTTP Authentication, scheme: {{=sd.scheme}} {{=sd.description || ''}}
+- HTTP Authentication, scheme: {{=sd.scheme}}{{? sd.description }}<br/>{{=sd.description}}{{?}}
 {{?}}
 {{? sd.type == 'oauth2'}}
 - oAuth2 authentication. {{=sd.description || ''}}


### PR DESCRIPTION
This is a minor improvement that adds a line break between auth details and description, as there's currently nothing separating the details and description which makes it hard to read.

Before:

<img width="590" alt="Screenshot 2020-08-03 at 09 00 08" src="https://user-images.githubusercontent.com/102141/89160238-a765c080-d568-11ea-9f81-439e51d13928.png">

After:

<img width="590" alt="Screenshot 2020-08-03 at 09 05 01" src="https://user-images.githubusercontent.com/102141/89160243-aaf94780-d568-11ea-9215-26196b2a2243.png">

An alternative approach is to use a period (.) to separate details and description. 