### PR TITLE
OpenAPI 3: Use the example field when provided in a Media Type Object

### DIFF
--- a/lib/openapi3.js
+++ b/lib/openapi3.js
@@ -119,7 +119,7 @@ function fakeProdCons(data) {
                     data.bodyParameter.exampleValues.description = op.requestBody.content[rb].examples[key].description;
                 }
                 else if (op.requestBody.content[rb].example) {
-                  data.bodyParameter.exampleValues.object = op.requestBody.content[rb].example;
+                    data.bodyParameter.exampleValues.object = op.requestBody.content[rb].example;
                 }
                 else {
                     data.bodyParameter.exampleValues.object = common.getSample(op.requestBody.content[rb].schema, data.options, { skipReadOnly: true, quiet: true }, data.api);

--- a/lib/openapi3.js
+++ b/lib/openapi3.js
@@ -118,6 +118,9 @@ function fakeProdCons(data) {
                     data.bodyParameter.exampleValues.object = op.requestBody.content[rb].examples[key].value;
                     data.bodyParameter.exampleValues.description = op.requestBody.content[rb].examples[key].description;
                 }
+                else if (op.requestBody.content[rb].example) {
+                  data.bodyParameter.exampleValues.object = op.requestBody.content[rb].example;
+                }
                 else {
                     data.bodyParameter.exampleValues.object = common.getSample(op.requestBody.content[rb].schema, data.options, { skipReadOnly: true, quiet: true }, data.api);
                 }


### PR DESCRIPTION
Currently for OpenAPI3, when generating examples for `requestBody`, widdershins only considers the `examples` property and the `example` property of the schema. This adds support for using the `example` property of a Media Type Object.