### PR TITLE
Fixes code break when title not found

### DIFF
--- a/lib/apiblueprint.js
+++ b/lib/apiblueprint.js
@@ -15,7 +15,7 @@ function convert(api, options) {
         while (lines[index] && !lines[index].startsWith('# ') && !lines[index].startsWith('==') && (index < lines.length)) {
             index++;
         }
-        if (lines[index].startsWith('# ')) {
+        if ((index < lines.length) && lines[index].startsWith('# ')) {
             title = lines[index];
         }
         else {


### PR DESCRIPTION
When an apiDoc in string format is passed, and if it doesn't contain any title, then code breaks as the index equals number of lines(reached EOF). Added a check for the same before checking if the current line(which can be EOF) is a title or not