### PR TITLE
#192 - adding support of multiple examples for body requests

### DIFF
--- a/defs/issue192.json
+++ b/defs/issue192.json
@@ -1,0 +1,52 @@
+{
+    "openapi": "3.0.1",
+    "info": {
+        "title": "API",
+        "version": "1.0.0"
+    },
+    "paths": {
+        "/test": {
+            "post": {
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "requestBody": {
+                    "description": "Overall description",
+                    "content": {
+                        "application/json": {
+                            "examples": {
+                                "MyFirstExample": {
+                                    "value": {
+                                        "test": 123
+                                    },
+                                    "description": "Test description one"
+                                },
+                                "MySecondExample": {
+                                    "value": {
+                                        "test": 456
+                                    },
+                                    "description": "second test description"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "Cat": {
+                "type": "object"
+            },
+            "Dog": {
+                "type": "object"
+            },
+            "Hamster": {
+                "type": "object"
+            }
+        }
+    }
+}

--- a/lib/openapi3.js
+++ b/lib/openapi3.js
@@ -330,7 +330,7 @@ function getParameters(data) {
 }
 
 function getBodyParameterExamples(data) {
-    let obj = data.bodyParameter.exampleValues.object;
+    let examples = [];
     let content = '';
     let xmlWrap = false;
     if (data.bodyParameter.schema && data.bodyParameter.schema.xml) {
@@ -339,35 +339,66 @@ function getBodyParameterExamples(data) {
     else if (data.bodyParameter.schema && data.bodyParameter.schema["x-widdershins-oldRef"]) {
         xmlWrap = data.bodyParameter.schema["x-widdershins-oldRef"].split('/').pop();
     }
-    if (common.doContentType(data.consumes, 'json')) {
-        content += '```json\n';
-        content += common.safejson(obj, null, 2) + '\n';
-        content += '```\n\n';
-    }
-    if (common.doContentType(data.consumes, 'yaml')) {
-        content += '```yaml\n';
-        content += yaml.stringify(obj) + '\n';
-        content += '```\n\n';
-    }
-    if (common.doContentType(data.consumes, 'text')) {
-        content += '```\n';
-        content += yaml.stringify(obj) + '\n';
-        content += '```\n\n';
-    }
-    if (common.doContentType(data.consumes, 'form')) {
-        content += '```yaml\n';
-        content += yaml.stringify(obj) + '\n';
-        content += '```\n\n';
-    }
-    if (common.doContentType(data.consumes, 'xml') && (typeof obj === 'object')) {
-        if (xmlWrap) {
-            var newObj = {};
-            newObj[xmlWrap] = obj;
-            obj = newObj;
+
+    let requestBody = data.operation.requestBody;
+    for (let reqBodyExample in requestBody.content) {
+        for (let ct in requestBody.content) {
+            let contentType = requestBody.content[ct];
+            let cta = [ct];
+            // support multiple embedded body examples
+            if (contentType.examples) {
+                for (let ctei in contentType.examples) {
+                    let example = contentType.examples[ctei];
+                    examples.push({description:example.description,value: common.clean(example.value), cta: cta});
+                }
+            }
+            else if (contentType.example) {
+                examples.push({description:reqBodyExample+' '+data.translations.requestBody,value:common.clean(contentType.example.value), cta: cta});
+            }
+            else if (contentType.schema) {
+                let obj = contentType.schema;
+                let xmlWrap = false;
+                if (obj && obj.xml && obj.xml.name) {
+                    xmlWrap = obj.xml.name;
+                }
+                else if (obj["x-widdershins-oldRef"]) {
+                    xmlWrap = obj["x-widdershins-oldRef"].split('/').pop();
+                }
+                examples.push({description:reqBodyExample+' '+data.translations.requestBody,value:common.getSample(obj,data.options,{skipWriteOnly:true},data.api), cta: cta, xmlWrap: xmlWrap});
+            }
         }
-        content += '```xml\n';
-        content += xml.getXml(JSON.parse(common.safejson(obj)), '@', '', true, '  ', false) + '\n';
-        content += '```\n\n';
+    }
+    let lastDesc = '';
+    for (let example of examples) {
+        if (example.description && example.description !== lastDesc) {
+            content += '> ' + example.description + '\n\n';
+            lastDesc = example.description;
+        }
+        if (common.doContentType(example.cta, 'json')) {
+            content += '```json\n';
+            content += common.safejson(example.value, null, 2) + '\n';
+            content += '```\n\n';
+        }
+        if (common.doContentType(example.cta, 'yaml')) {
+            content += '```yaml\n';
+            content += yaml.stringify(example.value) + '\n';
+            content += '```\n\n';
+        }
+        if (common.doContentType(example.cta, 'text')) {
+            content += '```\n';
+            content += JSON.stringify(example.value) + '\n';
+            content += '```\n\n';
+        }
+        let xmlObj = example.value;
+        if (example.xmlWrap) {
+            xmlObj = {};
+            xmlObj[example.xmlWrap] = example.value;
+        }
+        if ((typeof xmlObj === 'object') && common.doContentType(example.cta, 'xml')) {
+            content += '```xml\n';
+            content += xml.getXml(JSON.parse(common.safejson(xmlObj)), '@', '', true, '  ', false) + '\n';
+            content += '```\n\n';
+        }
     }
     return content;
 }

--- a/templates/openapi3/operation.dot
+++ b/templates/openapi3/operation.dot
@@ -31,7 +31,7 @@
 > Body parameter
 
 {{? data.bodyParameter.exampleValues.description }}
-> {{= data.bodyParameter.exampleValues.description }}
+> {{= data.operation.requestBody.description }}
 {{?}}
 
 {{= data.utils.getBodyParameterExamples(data) }}


### PR DESCRIPTION
Hi,

I added support of multiple examples and tested on attached example `defs/issue192.json`. I inspired myself by the response examples code and reused what I could.

Please have a look :)
