### PR TITLE
docs: add Admetricks API to WiTW section

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ Please feel free to add a link to your API documentation here.
 * [LeApp daemon API](https://leapp-to.github.io/shins/index.html)
 * [Shutterstock API](https://api-reference.shutterstock.com/)
 * [Shotstack Video Editing API](https://shotstack.io/docs/api/index.html)
+* [Admetricks API](http://dev.admetricks.com/)
 
 ### Widdershins and ReSlate
 


### PR DESCRIPTION
We started using Widdershins about 2 months ago when we first got around to documenting our APIs. It's worked great so far.

Our stack:

- Python 3.8
- Django with DRF Spectacular
- Slate 2.7.1

It's available [here](http://dev.admetricks.com/)