### PR TITLE
fix: Support for multiple response content-types see #436

### DIFF
--- a/lib/openapi3.js
+++ b/lib/openapi3.js
@@ -427,22 +427,24 @@ function getResponses(data) {
     for (let r in data.operation.responses) {
         if (!r.startsWith('x-')) {
             let response = data.operation.responses[r];
-            let entry = {};
-            entry.status = r;
-            entry.meaning = (r === 'default' ? data.translations.responseDefault : data.translations.responseUnknown);
-            var url = '';
-            for (var s in common.statusCodes) {
-                if (common.statusCodes[s].code === r) {
-                    entry.meaning = common.statusCodes[s].phrase;
-                    url = common.statusCodes[s].spec_href;
-                    break;
-                }
-            }
-            if (url) entry.meaning = '[' + entry.meaning + '](' + url + ')';
-            entry.description = (typeof response.description === 'string' ? response.description.trim() : undefined);
-            entry.schema = data.translations.schemaNone;
             for (let ct in response.content) {
+                let entry = {};
+                entry.status = r;
+                entry.meaning = (r === 'default' ? data.translations.responseDefault : data.translations.responseUnknown);
+                var url = '';
+                for (var s in common.statusCodes) {
+                    if (common.statusCodes[s].code === r) {
+                        entry.meaning = common.statusCodes[s].phrase;
+                        url = common.statusCodes[s].spec_href;
+                        break;
+                    }
+                }
+                if (url) entry.meaning = '[' + entry.meaning + '](' + url + ')';
+                entry.description = (typeof response.description === 'string' ? response.description.trim() : undefined);
+                entry.schema = data.translations.schemaNone;
+
                 let contentType = response.content[ct];
+                entry.contentType = ct;
                 if (contentType.schema) {
                     entry.type = contentType.schema.type;
                     entry.schema = data.translations.schemaInline;
@@ -457,10 +459,11 @@ function getResponses(data) {
                         entry.schema = contentType.schema.type;
                     }
                 }
+
+                entry.content = response.content;
+                entry.links = response.links;
+                responses.push(entry);
             }
-            entry.content = response.content;
-            entry.links = response.links;
-            responses.push(entry);
         }
     }
     return responses;

--- a/templates/openapi3/responses.def
+++ b/templates/openapi3/responses.def
@@ -13,9 +13,9 @@
 {{= data.tags.section }}
 <h3 id="{{=data.operationUniqueSlug}}-responses">Responses</h3>
 
-|Status|Meaning|Description|Schema|
-|---|---|---|---|
-{{~ data.responses :r}}|{{=r.status}}|{{=r.meaning}}|{{=r.description || 'none'}}|{{=r.schema}}|
+|Content-Type|Status|Meaning|Description|Schema|
+|---|---|---|---|---|
+{{~ data.responses :r}}|{{=r.contentType}}|{{=r.status}}|{{=r.meaning}}|{{=r.description || 'none'}}|{{=r.schema}}|
 {{~}}
 
 {{ data.responseSchemas = false; }}


### PR DESCRIPTION
It could be this simple.

However `code` and `description` are in the outer object and don't require calculation each loop.

I'll push another commit which does the logic on those first then reuses the result for the inner loop.