### PR TITLE
docs: add Eqivo API to WiTW section

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ Please feel free to add a link to your API documentation here.
 * [Shutterstock API](https://api-reference.shutterstock.com/)
 * [Shotstack Video Editing API](https://shotstack.io/docs/api/index.html)
 * [Admetricks API](http://dev.admetricks.com/)
+* [Eqivo API](https://eqivo.org/)
 
 ### Widdershins and ReSlate
 


### PR DESCRIPTION
After some substantial research, Widdershins is the tool of choice for documenting our API. The output is available [here](https://eqivo.org).