### PR TITLE
Suppress doT logging when options.verbose is not true

### DIFF
--- a/widdershins.js
+++ b/widdershins.js
@@ -8,6 +8,8 @@ const url = require('url');
 const yaml = require('yaml');
 const fetch = require('node-fetch');
 
+const doT = require('dot');
+
 const converter = require('./lib/index.js');
 
 var argv = require('yargs')
@@ -185,6 +187,10 @@ if (argv.respec) {
 }
 if (options.respec) options.html = true;
 if (options.html) options.omitHeader = true;
+
+// doT.log is defaultly true.
+// if options.verbose undefined or false, then, doT.log = false
+if (options.verbose !== true) doT.log = false;
 
 if (argv.environment) {
     var e = fs.readFileSync(path.resolve(argv.environment),'utf8');


### PR DESCRIPTION
When processing, logs like the following are output to stdout from the dot module, which dirties the output when the -o option is not specified.

Since doT.log is true by default, setting doT.log to false when options.verbose is not true will enhance overall consistency.

```
Compiling all doT templates...
Loaded def authentication.def
Loaded def authentication_none.def
Loaded def callbacks.def
Loaded def debug.def
```
